### PR TITLE
Make background colors in the nav consistent

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -225,7 +225,7 @@ fieldset[disabled] .btn-xl.active {
 
 .navbar-default .navbar-toggle:hover,
 .navbar-default .navbar-toggle:focus {
-    background-color: #18a1fd;
+    background-color: #20bba6;
 }
 
 .navbar-default .nav li a {
@@ -251,7 +251,7 @@ fieldset[disabled] .btn-xl.active {
 .navbar-default .navbar-nav>.active>a:hover,
 .navbar-default .navbar-nav>.active>a:focus {
     color: #fff;
-    background-color: #18a1fd;
+    background-color: #20bba6;
 }
 
 @media(min-width:768px) {


### PR DESCRIPTION
While scrolling the page, a funny color pops up in the navigation every now and then.

This PR replaces the funny color with a proper one.

![image](https://cloud.githubusercontent.com/assets/5222805/19322009/f4c7ef0c-90bf-11e6-9826-5785addfaa99.png)
